### PR TITLE
Added outPath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,28 @@ Parameter | Description
 `href`    | The original value of the `href` attribute currently being transformed.
 `locale`  | The locale code of the locale currently being applied to the html document. This is also the name of the current locale's directory. (Eg: `en`, `de`, etc.)
 
+#### outPath
+- **Accepts**: _Function(`base`, `path`, `localeId`)_, `string`
+- **Default**: `return path.replace(base, base + localeId + '/');`
+
+A function to compute a custom output path for localized files.
+
+Example for files of the form `index.de.html`
+
+```js
+
+  gulp.task('localize', function () {
+    return gulp.src('*.html')
+      .pipe(l10n({
+        outPath: function (base, path, localeId) {
+          return path.slice(0, -4) + localeId + ".html";
+        }
+      }))
+      .pipe(gulp.dest(pkg.release));
+  });
+
+```
+
 # Contributing
 The default Gulp task watches all files and runs tests and code coverage.
 

--- a/index.js
+++ b/index.js
@@ -30,6 +30,9 @@ module.exports = function(options) {
       });
     };
   };
+  var outPath = options.outPath || function (base, path, localeId) {
+    return path.replace(base, base + localeId + '/');
+  };
 
   function localizeFiles(file, enc, cb) {
     // ignore empty files
@@ -49,7 +52,7 @@ module.exports = function(options) {
         var localizedFile = file.clone();
 
         // place files in the locale's subdirectory
-        localizedFile.path = localizedFile.path.replace(localizedFile.base, localizedFile.base + id + '/');
+        localizedFile.path = outPath(localizedFile.base, localizedFile.path, id);
 
         var contents = s18n(String(localizedFile.contents), {
           nativeLocale: localeCaches[cacheId].locales[localeCaches[cacheId].native],

--- a/test/test.js
+++ b/test/test.js
@@ -325,4 +325,32 @@ describe('gulp-l10n: l10n()', function() {
         }));
   });
 
+  it('should l10n to custom paths', function(done) {
+    gulp.src(fixtures('{de,en,fr}.json'))
+      .pipe(l10n.setLocales()
+        .on('finish', function(err) {
+          if (err) {
+            console.error(err);
+          }
+          var results = {};
+          var expected = {
+            'a.de.html': '<p>Thís ís á tést.</p>\n',
+            'a.fr.html': '<p>Thís ís á tést.</p>\n'
+          };
+          gulp.src(fixtures('a.html'))
+            .pipe(l10n({
+              outPath: function (base, path, localeId) {
+                return path.slice(0, -4) + localeId + '.html';
+              }
+            }))
+            .on('data', function(file) {
+              results[file.path.replace(file.base, '')] = String(file.contents);
+            })
+            .on('finish', function() {
+              assert.deepEqual(expected, results);
+              done();
+            });
+        }));
+  });
+
 });


### PR DESCRIPTION
Just a proposal, I use it myself but it changes the API

outPath allows overriding default output path. It is a function taking
(base, path, localeId) and returning the output path.

For instance, to get files of the form index.fr.html:

```
gulp.task('localize', ['load-locales'], function () {
  return gulp.src('*.html')
    .pipe(l10n({
      outPath: function (base, path, localeId) {
        return path.slice(0, -4) + localeId + ".html";
      }
    }))
    .pipe(gulp.dest('dist'));
});
```
