### PR TITLE
cross-platform path resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ var l10n = require('gulp-l10n');
 var opts = {
   elements: ['title', 'p', 'h1'],
   attributes: ['alt', 'title'],
-  directives: 'translate=yes'
+  directives: 'translate=yes',
   attributeSetter: 'translate-attrs'
 };
 

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 var through = require('through2');
 var gutil = require('gulp-util');
 var s18n = require('s18n');
+var path = require('path');
 
 var PLUGIN_NAME = 'gulp-l10n';
 
@@ -110,7 +111,7 @@ module.exports.setLocales = function(options) {
       return;
     }
     // file is buffer
-    var localeId = file.path.split('/').pop().split('.').shift();
+    var localeId = path.basename(file.path, '.json');
     var locale = JSON.parse(String(file.contents));
     localeCaches[options.cacheId].locales[localeId] = locale;
     cb();

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "gulp-util": "^3.0.6",
+    "path": "^0.12.7",
     "s18n": "^2.0.0",
     "through2": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "dependencies": {
     "gulp-util": "^3.0.6",
-    "path": "^0.12.7",
     "s18n": "^2.0.0",
     "through2": "^2.0.0"
   },


### PR DESCRIPTION
This has been very frustrating for me to debug, but now it seems that author of this gulp module is using OSX or Linux machine. 

I am  a Windows user myself  and I have a big problem with this bit right here in `index.js`:

```
function cacheLocale(file, enc, cb) {
    // ignore empty files
    if (file.isNull()) {
        cb(null);
        return;
    }

    if (file.isStream()) {
        cb(new gutil.PluginError(PLUGIN_NAME, 'streaming not supported'));
        return;
    }

    // file is buffer
    var localeId = file.path.split('/').pop().split('.').shift();
    var locale = JSON.parse(String(file.contents));
    localeCaches[options.cacheId].locales[localeId] = locale;
    cb();
}
```

Line for finding `localeId` is not working on Windows. Filepaths on different OSs are written differently. For a cross-platform solution module `path` should be used.  Respective line should change to this:

```
var localeId = path.basename(file.path, '.json');
```

Also, I fixed a typo in README.md.
